### PR TITLE
Fixed other players blinking when instanced and fixed the collision problem

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -148,22 +148,22 @@ AddEventHandler('instance:onInvite', function(_instance, type, data)
 		host = _instance,
 		data = data
 	}
+	Citizen.CreateThread(function()
+		while instanceInvite do
+			Citizen.Wait(0)
 
+			ESX.ShowHelpNotification(_U('press_to_enter'))
+
+			if IsControlJustReleased(0, 38) then
+				EnterInstance(instanceInvite)
+				ESX.ShowNotification(_U('entered_instance'))
+				instanceInvite = nil
+			end
+		end
+	end)
+	
 	Citizen.CreateThread(function()
 		-- Controls for invite
-		Citizen.CreateThread(function()
-			while instanceInvite do
-				Citizen.Wait(0)
-
-				ESX.ShowHelpNotification(_U('press_to_enter'))
-
-				if IsControlJustReleased(0, 38) then
-					EnterInstance(instanceInvite)
-					ESX.ShowNotification(_U('entered_instance'))
-					instanceInvite = nil
-				end
-			end
-		end)
 		Citizen.Wait(10000)
 
 		if instanceInvite then
@@ -171,6 +171,7 @@ AddEventHandler('instance:onInvite', function(_instance, type, data)
 			instanceInvite = nil
 		end
 	end)
+		
 end)
 
 RegisterInstanceType('default')

--- a/client/main.lua
+++ b/client/main.lua
@@ -193,7 +193,7 @@ end)
 
 Citizen.CreateThread(function()
 	while true do
-		Citizen.Wait(10)
+		Citizen.Wait(0)
 		local playerPed = PlayerPedId()
 
 		-- Hide all these players
@@ -203,7 +203,7 @@ Citizen.CreateThread(function()
 			if NetworkIsPlayerActive(player) then
 				local otherPlayerPed = GetPlayerPed(player)
 				SetEntityVisible(otherPlayerPed, false, false)
-				SetEntityNoCollisionEntity(playerPed, otherPlayerPed, false)
+				SetEntityNoCollisionEntity(otherPlayerPed, playerPed, true)
 			end
 		end
 	end


### PR DESCRIPTION

Since now the invisibility is updated every frame, the collision is only removed in the same frame. I also noticed that the ped order was wrong, because players were colliding when they were in diferent instances.